### PR TITLE
Update SEO metadata for new domain launch

### DIFF
--- a/assets/js/cms.js
+++ b/assets/js/cms.js
@@ -646,7 +646,7 @@ class CMSManager {
     <meta name="description" content="Personal projects and side experiments by Pavan Kumar Dharmoju. Real stories about building tools, learning new tech, and creative coding projects outside of work.">
     <meta name="keywords" content="Side Projects, Personal Projects, Build Diary, Tech Experiments, Creative Coding, Open Source, Learning Journey, Developer Life">
     <meta name="author" content="Pavan Kumar Dharmoju">
-    <link rel="canonical" href="https://pavankumardharmoju.github.io/work">
+    <link rel="canonical" href="https://pixelsbypavan.com/work">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap');

--- a/blogs.html
+++ b/blogs.html
@@ -19,7 +19,18 @@
     <meta name="anthropic-ai" content="noindex">
     <meta name="Claude-Web" content="noindex">
     
-    <link rel="canonical" href="https://pavankumardharmoju.github.io/blogs">
+    <link rel="canonical" href="https://pixelsbypavan.com/blogs">
+    <!-- Social sharing (Open Graph / Twitter) -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://pixelsbypavan.com/blogs">
+    <meta property="og:title" content="Technical Articles - Pavan Kumar Dharmoju | Code & Insights">
+    <meta property="og:description" content="Technical articles and insights from Pavan Kumar Dharmoju. Deep dives into AI, machine learning, data engineering, and real-world implementation stories.">
+    <meta property="og:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
+    <meta property="og:site_name" content="Pavan Kumar Dharmoju">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Technical Articles - Pavan Kumar Dharmoju | Code & Insights">
+    <meta name="twitter:description" content="Technical articles and insights from Pavan Kumar Dharmoju. Deep dives into AI, machine learning, data engineering, and real-world implementation stories.">
+    <meta name="twitter:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap');

--- a/cms_generator.py
+++ b/cms_generator.py
@@ -28,7 +28,7 @@ class HTMLGenerator:
     <meta name="description" content="Personal projects and side experiments by Pavan Kumar Dharmoju. Real stories about building tools, learning new tech, and creative coding projects outside of work.">
     <meta name="keywords" content="Side Projects, Personal Projects, Build Diary, Tech Experiments, Creative Coding, Open Source, Learning Journey, Developer Life">
     <meta name="author" content="Pavan Kumar Dharmoju">
-    <link rel="canonical" href="https://pavankumardharmoju.github.io/work">
+    <link rel="canonical" href="https://pixelsbypavan.com/work">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap');

--- a/contact.html
+++ b/contact.html
@@ -19,7 +19,18 @@
     <meta name="anthropic-ai" content="noindex">
     <meta name="Claude-Web" content="noindex">
     
-    <link rel="canonical" href="https://pavankumardharmoju.github.io/contact">
+    <link rel="canonical" href="https://pixelsbypavan.com/contact">
+    <!-- Social sharing (Open Graph / Twitter) -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://pixelsbypavan.com/contact">
+    <meta property="og:title" content="Get in touch - Pavan Kumar Dharmoju | Let's build something meaningful">
+    <meta property="og:description" content="Reach out to discuss AI projects, research collaborations, or interesting problems worth solving. Always interested in meaningful conversations about technology.">
+    <meta property="og:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
+    <meta property="og:site_name" content="Pavan Kumar Dharmoju">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Get in touch - Pavan Kumar Dharmoju | Let's build something meaningful">
+    <meta name="twitter:description" content="Reach out to discuss AI projects, research collaborations, or interesting problems worth solving. Always interested in meaningful conversations about technology.">
+    <meta name="twitter:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap');

--- a/index.html
+++ b/index.html
@@ -19,7 +19,18 @@
     <meta name="anthropic-ai" content="noindex">
     <meta name="Claude-Web" content="noindex">
     
-    <link rel="canonical" href="https://pavankumardharmoju.github.io/">
+    <link rel="canonical" href="https://pixelsbypavan.com/">
+    <!-- Social sharing (Open Graph / Twitter) -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://pixelsbypavan.com/">
+    <meta property="og:title" content="Pavan Kumar Dharmoju - Building AI that works | ML Engineer & Data Scientist">
+    <meta property="og:description" content="AI Engineer building systems that work in the real world. Currently at Marketing Attribution LLC optimizing marketing strategies with machine learning. MS AI from Northwestern.">
+    <meta property="og:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
+    <meta property="og:site_name" content="Pavan Kumar Dharmoju">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Pavan Kumar Dharmoju - Building AI that works | ML Engineer & Data Scientist">
+    <meta name="twitter:description" content="AI Engineer building systems that work in the real world. Currently at Marketing Attribution LLC optimizing marketing strategies with machine learning. MS AI from Northwestern.">
+    <meta name="twitter:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
     
     <!-- AI Protection Script -->
     <script src="assets/js/ai-protection.js"></script>
@@ -36,6 +47,31 @@
             letter-spacing: -0.01em;
         }
     </style>
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Pavan Kumar Dharmoju",
+    "url": "https://pixelsbypavan.com/",
+    "image": "https://pixelsbypavan.com/assets/img/pavan.jpg",
+    "jobTitle": "AI Engineer",
+    "worksFor": {
+        "@type": "Organization",
+        "name": "Marketing Attribution LLC"
+    },
+    "alumniOf": {
+        "@type": "CollegeOrUniversity",
+        "name": "Northwestern University"
+    },
+    "sameAs": [
+        "https://github.com/pavankumardharmoju",
+        "https://linkedin.com/in/pavandharmoju/",
+        "https://scholar.google.com/citations?user=hxxQ3D4AAAAJ",
+        "https://instagram.com/pixelsbypavan",
+        "https://pixelsbypavan.substack.com"
+    ]
+}
+    </script>
 </head>
 <body class="bg-white">
     <div class="max-w-4xl mx-auto px-4 sm:px-8">

--- a/photography.html
+++ b/photography.html
@@ -19,7 +19,18 @@
     <meta name="anthropic-ai" content="noindex">
     <meta name="Claude-Web" content="noindex">
     
-    <link rel="canonical" href="https://pavankumardharmoju.github.io/photography">
+    <link rel="canonical" href="https://pixelsbypavan.com/photography">
+    <!-- Social sharing (Open Graph / Twitter) -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://pixelsbypavan.com/photography">
+    <meta property="og:title" content="Photography - Pavan Kumar Dharmoju | Visual Stories Through Code and Light">
+    <meta property="og:description" content="Photography portfolio of Pavan Kumar Dharmoju - capturing moments between building AI systems. Street photography, landscapes, and technical documentation through a developer's lens.">
+    <meta property="og:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
+    <meta property="og:site_name" content="Pavan Kumar Dharmoju">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Photography - Pavan Kumar Dharmoju | Visual Stories Through Code and Light">
+    <meta name="twitter:description" content="Photography portfolio of Pavan Kumar Dharmoju - capturing moments between building AI systems. Street photography, landscapes, and technical documentation through a developer's lens.">
+    <meta name="twitter:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
     
     <!-- AI Protection Script -->
     <script src="assets/js/ai-protection.js"></script>

--- a/projects.html
+++ b/projects.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Project Build Log - Pavan Kumar Dharmoju</title>
+    <meta name="description" content="Build log of machine learning and software projects by Pavan Kumar Dharmoju - from experiments to shipped tools, with the lessons learned along the way.">
     
     <!-- AI Blocking Meta Tags -->
     <meta name="robots" content="index, follow, noai, noimageai">
@@ -16,7 +17,18 @@
     <meta name="anthropic-ai" content="noindex">
     <meta name="Claude-Web" content="noindex">
     <meta name="author" content="Pavan Kumar Dharmoju">
-    <link rel="canonical" href="https://pavankumardharmoju.github.io/projects">
+    <link rel="canonical" href="https://pixelsbypavan.com/projects">
+    <!-- Social sharing (Open Graph / Twitter) -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://pixelsbypavan.com/projects">
+    <meta property="og:title" content="Project Build Log - Pavan Kumar Dharmoju">
+    <meta property="og:description" content="Build log of machine learning and software projects by Pavan Kumar Dharmoju - from experiments to shipped tools, with the lessons learned along the way.">
+    <meta property="og:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
+    <meta property="og:site_name" content="Pavan Kumar Dharmoju">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Project Build Log - Pavan Kumar Dharmoju">
+    <meta name="twitter:description" content="Build log of machine learning and software projects by Pavan Kumar Dharmoju - from experiments to shipped tools, with the lessons learned along the way.">
+    <meta name="twitter:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
     
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/publications.html
+++ b/publications.html
@@ -19,7 +19,18 @@
     <meta name="anthropic-ai" content="noindex">
     <meta name="Claude-Web" content="noindex">
     
-    <link rel="canonical" href="https://pavankumardharmoju.github.io/publications">
+    <link rel="canonical" href="https://pixelsbypavan.com/publications">
+    <!-- Social sharing (Open Graph / Twitter) -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://pixelsbypavan.com/publications">
+    <meta property="og:title" content="Research Publications - Pavan Kumar Dharmoju | Academic Contributions & Paper Archive">
+    <meta property="og:description" content="Academic research publications and paper archive by Pavan Kumar Dharmoju. Peer-reviewed research in AI, machine learning, and biomedical applications with real citations and impact.">
+    <meta property="og:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
+    <meta property="og:site_name" content="Pavan Kumar Dharmoju">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Research Publications - Pavan Kumar Dharmoju | Academic Contributions & Paper Archive">
+    <meta name="twitter:description" content="Academic research publications and paper archive by Pavan Kumar Dharmoju. Peer-reviewed research in AI, machine learning, and biomedical applications with real citations and impact.">
+    <meta name="twitter:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap');

--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,6 @@
 # Robots.txt - Blocking AI crawlers and data scrapers
 # Personal portfolio of Pavan Kumar Dharmoju
-# Last updated: December 14, 2025
+# Last updated: August 1, 2026
 
 # Block all AI training and scraping bots
 User-agent: GPTBot
@@ -93,43 +93,14 @@ Disallow: /
 User-agent: AWS-*
 Disallow: /
 
-# Block content scraping and training data collection
+# All other crawlers (including search engines): allow the site,
+# but keep private/admin pages and raw data out of the index
 User-agent: *
 Disallow: /*.json$
 Disallow: /assets/js/
 Disallow: /cms.html
 Disallow: /work-admin.html
-
-# Allow legitimate search engines for public pages
-User-agent: Googlebot
-Allow: /index.html
-Allow: /work.html
-Allow: /projects.html
-Allow: /publications.html
-Allow: /photography.html
-Allow: /contact.html
-Disallow: /
-
-User-agent: Bingbot
-Allow: /index.html
-Allow: /work.html
-Allow: /projects.html
-Allow: /publications.html
-Allow: /photography.html
-Allow: /contact.html
-Disallow: /
-
-User-agent: DuckDuckBot
-Allow: /index.html
-Allow: /work.html
-Allow: /projects.html
-Allow: /publications.html
-Allow: /photography.html
-Allow: /contact.html
-Disallow: /
+Disallow: /embed-demo.html
 
 # Sitemap for legitimate indexing
-Sitemap: https://pavankumardharmoju.github.io/sitemap.xml
-
-# Crawl delay for all bots
-Crawl-delay: 10
+Sitemap: https://pixelsbypavan.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,39 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <!-- Only legitimate pages for search engines -->
     <url>
-        <loc>https://pavankumardharmoju.github.io/</loc>
-        <lastmod>2025-12-14</lastmod>
+        <loc>https://pixelsbypavan.com/</loc>
+        <lastmod>2026-08-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>1.0</priority>
     </url>
     <url>
-        <loc>https://pavankumardharmoju.github.io/work.html</loc>
-        <lastmod>2025-12-14</lastmod>
+        <loc>https://pixelsbypavan.com/work</loc>
+        <lastmod>2026-08-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
-        <loc>https://pavankumardharmoju.github.io/projects.html</loc>
-        <lastmod>2025-12-14</lastmod>
+        <loc>https://pixelsbypavan.com/projects</loc>
+        <lastmod>2026-08-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
-        <loc>https://pavankumardharmoju.github.io/publications.html</loc>
-        <lastmod>2025-12-14</lastmod>
+        <loc>https://pixelsbypavan.com/publications</loc>
+        <lastmod>2026-08-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://pavankumardharmoju.github.io/photography.html</loc>
-        <lastmod>2025-12-14</lastmod>
+        <loc>https://pixelsbypavan.com/photography</loc>
+        <lastmod>2026-08-01</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.6</priority>
     </url>
     <url>
-        <loc>https://pavankumardharmoju.github.io/contact.html</loc>
-        <lastmod>2025-12-14</lastmod>
+        <loc>https://pixelsbypavan.com/blogs</loc>
+        <lastmod>2026-08-01</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.6</priority>
+    </url>
+    <url>
+        <loc>https://pixelsbypavan.com/contact</loc>
+        <lastmod>2026-08-01</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.5</priority>
     </url>

--- a/work.html
+++ b/work.html
@@ -7,7 +7,18 @@
     <meta name="description" content="Personal projects and side experiments by Pavan Kumar Dharmoju. Real stories about building tools, learning new tech, and creative coding projects outside of work.">
     <meta name="keywords" content="Side Projects, Personal Projects, Build Diary, Tech Experiments, Creative Coding, Open Source, Learning Journey, Developer Life">
     <meta name="author" content="Pavan Kumar Dharmoju">
-    <link rel="canonical" href="https://pavankumardharmoju.github.io/work">
+    <link rel="canonical" href="https://pixelsbypavan.com/work">
+    <!-- Social sharing (Open Graph / Twitter) -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://pixelsbypavan.com/work">
+    <meta property="og:title" content="Build Diary - Pavan Kumar Dharmoju | Side Projects & Experiments">
+    <meta property="og:description" content="Personal projects and side experiments by Pavan Kumar Dharmoju. Real stories about building tools, learning new tech, and creative coding projects outside of work.">
+    <meta property="og:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
+    <meta property="og:site_name" content="Pavan Kumar Dharmoju">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Build Diary - Pavan Kumar Dharmoju | Side Projects & Experiments">
+    <meta name="twitter:description" content="Personal projects and side experiments by Pavan Kumar Dharmoju. Real stories about building tools, learning new tech, and creative coding projects outside of work.">
+    <meta name="twitter:image" content="https://pixelsbypavan.com/assets/img/pavan.jpg">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap');


### PR DESCRIPTION
Switch canonical URLs and sitemap references from the GitHub Pages domain to pixelsbypavan.com, and refresh sitemap entries/dates (including blogs). Add Open Graph and Twitter card metadata across key pages, plus Person JSON-LD on the homepage, to improve sharing and search visibility. Also simplify robots.txt rules to keep AI crawlers blocked while allowing general indexing except for admin/raw-data paths.